### PR TITLE
Create kafka module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Run setup script
 make setup
 ```
 
+
 ## Running code
 
 ```bash
@@ -23,4 +24,43 @@ where create_kafka.json contains input arguments. For example:
         
     }
 }
+```
+## Testing with Ansible Playbooks
+A further way to run / test the code locally is with the use of an [Ansible Playbook](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#verifying-your-module-code-in-a-playbook). 
+To do so the following steps are required:
 
+- run `make local-dev` to create a local Ansible Library collection in the root of the project. This will copy existing modules to the collection. 
+- a playbook can be created in the root of the project and ran via the `ansible-playbook` command. For example:
+
+```bash
+ansible-playbook 'playbook.yaml' -vvv
+```
+
+where playbook.yml contains the following:
+
+```yaml
+---
+- name: Create_kafka test
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  tasks:
+    - name: Create Kafka
+      create_kafka:
+        name: kafka-name
+```
+
+**Note:**
+The `create_kafka` command in the task needs to be the **Fully Qualified Name** of the module for collection developemnet i.e. `redhat.rhoask.create_kafka`.
+
+
+```yaml
+...
+  gather_facts: true
+  tasks:
+    - name: Create Kafka
+      redhat.rhosak.create_kafka:
+        name: kafka-name
+...
+```
+Just remember to add the module back to the collection when you are done with the testing againsta a playbook.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 Red Hat, Inc. 
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
  .PHONY: setup 
 setup: 
 	./scripts/setup.sh
+
+.PHONY: local-dev
+ local-dev:
+ 	./scripts/local-dev.sh

--- a/library/create_kafka.py
+++ b/library/create_kafka.py
@@ -1,0 +1,250 @@
+#!/usr/bin/python
+
+
+from __future__ import (absolute_import, division, print_function)
+from sys import api_version
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: create_kafka
+
+short_description: Create Red Hat OpenShift Streams for Apache Kafka Instance
+
+# If this is part of a collection, you need to use semantic versioning,
+# i.e. the version is of the form "2.5.0" and not "2.4".
+version_added: "0.1.0"
+
+description: Create Red Hat OpenShift Streams for Apache Kafka Instance
+
+options:
+    name:
+        description: Name of the Kafka instance
+        required: true
+        type: str
+    cloud_provider:
+        description: Cloud provider for the Kafka instance
+        required: false
+        type: str
+        default: aws
+    region:
+        description: Region of the Kafka instance
+        required: false
+        type: str
+        default: eu-west-1
+    reauthentication_enabled:
+        description: Reauthentication enabled for the Kafka instance
+        required: false
+        type: bool
+        default: true
+    plan:
+        description: Plan for the Kafka instance
+        required: false
+        type: str
+        default: ""
+    billing_cloud_account_id:
+        description: Billing cloud account id for the Kafka instance
+        required: false
+        type: str
+        default: ""
+    marketplace:
+        description: Marketplace for the Kafka instance
+        required: false
+        type: str
+        default: ""
+    billing_model:
+        description: Billing model for the Kafka instance
+        required: false
+        type: str
+        default: marketplace
+    instance_type:
+        description: Instance type for the Kafka instance
+        required: false
+        type: str
+        default: developer
+ 
+# Specify this value according to your collection
+# in format of namespace.collection.doc_fragment_name
+extends_documentation_fragment:
+    - my_namespace.my_collection.my_doc_fragment_name
+
+author:
+    - Red Hat Developer
+'''
+
+EXAMPLES = r'''
+# Pass in a message
+  - name: Create kafka
+    create_kafka:
+      name: "struttin"
+    register:
+      kafka_req_resp 
+
+ 
+'''
+
+RETURN = r'''
+# These are examples of possible return values, and in general should use other names for return values.
+original_message:
+    description: The original kafka request payload that was passed in.
+    type: dict
+    returned: always
+    sample: "invocation": {
+        "module_args": {
+            "billing_cloud_account_id": "",
+            "billing_model": "marketplace",
+            "cloud_provider": "aws",
+            "instance_type": "developer",
+            "marketplace": "",
+            "name": "struttin",
+            "plan": "",
+            "reauthentication_enabled": "True",
+            "region": "eu-west-1"
+        }
+message:
+    description: The output error / exception message that is returned in the case the module generates an error / exception.
+    type: dict
+    returned: in case of error / exception
+    sample: "original_message": {
+            "billing_cloud_account_id": "",
+            "billing_model": "marketplace",
+            "cloud_provider": "aws",
+            "instance_type": "developer",
+            "marketplace": "",
+            "name": "struttin",
+            "plan": "",
+            "reauthentication_enabled": "True",
+            "region": "eu-west-1"
+        }
+kafka_req_resp:
+    description: The response object from the Kafka_mgmt API.
+    "changed": true,
+        "failed": false,
+        "kafka_req_resp": {
+            "admin_api_server_url": "http://localhost:8000/data/kafka",
+            "billing_cloud_account_id": "",
+            "billing_model": "marketplace",
+            "bootstrap_server_host": "localhost:8000",
+            "browser_url": "http://localhost:8080/calbu9ccff6bdd4jsg30/dashboard",
+            "cloud_provider": "aws",
+            "created_at": "2020-10-05T12:51:24.053142+00:00",
+            "egress_throughput_per_sec": "1Mi",
+            "expires_at": "2022-06-18T05:27:01.816619+00:00",
+            "href": "/api/kafkas_mgmt/v1/kafkas/68Pr91QnNwW6Wis7J7jxM",
+            "id": "68Pr91QnNwW6Wis7J7jxM",
+            "ingress_throughput_per_sec": "1Mi",
+            "instance_type": "developer",
+            "instance_type_name": "Trial",
+            "kafka_storage_size": "10Gi",
+            "kind": "Kafka",
+            "marketplace": "",
+            "max_connection_attempts_per_sec": 50.0,
+            "max_data_retention_period": "P14D",
+            "max_partitions": 100.0,
+            "multi_az": false,
+            "name": "struttin",
+            "owner": "dsaridak",
+            "plan": "",
+            "reauthentication_enabled": true,
+            "region": "us-east-1",
+            "size_id": "x1",
+            "status": "ready",
+            "total_max_connections": 100.0,
+            "updated_at": "2020-10-05T12:56:36.362208+00:00",
+            "version": "3.0.1"
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import rhoas_kafka_mgmt_sdk
+from rhoas_kafka_mgmt_sdk.api import default_api
+from rhoas_kafka_mgmt_sdk.model.kafka_request_payload import KafkaRequestPayload
+import auth.rhoas_auth as auth
+
+def run_module():
+    # define available arguments/parameters a user can pass to the module
+    module_args = dict(
+        name=dict(type='str', required=True),
+        cloud_provider=dict(type='str', required=False, default='aws'),
+        region=dict(type='str', required=False, default="eu-west-1"),
+        reauthentication_enabled=dict(type='bool', required=False, default=True),
+        plan=dict(type='str', required=False, default=""),
+        billing_cloud_account_id=dict(type='str', required=False, default=""),
+        marketplace=dict(type='str', required=False, default=""),
+        billing_model=dict(type='str', required=False, default="marketplace"),
+        instance_type=dict(type='str', required=False, default="developer"),
+    )
+
+    # seed the result dict in the object
+    # we primarily care about changed and state
+    # changed is if this module effectively modified the target
+    # state will include any data that you want your module to pass back
+    # for consumption, for example, in a subsequent task
+    result = dict(
+        changed=False,
+        original_message='',
+        message='',
+        kafka_req_resp=dict
+    )
+
+    # the AnsibleModule object will be our abstraction working with Ansible
+    # this includes instantiation, a couple of common attr would be the
+    # args/params passed to the execution, as well as if the module
+    # supports check mode
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    # if the user is working with this module in only check mode we do not
+    # want to make any changes to the environment, just return the current
+    # state with no modifications
+    # module.check_mode = False
+    if module.check_mode:
+        module.exit_json(**result)
+
+    token = auth.get_access_token()
+    
+    configuration = rhoas_kafka_mgmt_sdk.Configuration(
+        # host = "https://api.openshift.com",
+        # for use with testing / mocking
+        host = "http://localhost:8000",
+    )
+    
+    configuration.access_token = token["access_token"]
+    # Enter a context with an instance of the API client
+    with rhoas_kafka_mgmt_sdk.ApiClient(configuration) as api_client:
+        # Create an instance of the API class
+        api_instance = default_api.DefaultApi(api_client)
+        _async = True # bool | Perform the action in an asynchronous manner
+        kafka_request_payload = KafkaRequestPayload(
+            cloud_provider=module.params['cloud_provider'],
+            name=module.params['name'],
+            region=module.params['region'],
+            reauthentication_enabled=True,
+            plan=module.params['plan'],
+            billing_cloud_account_id=module.params['billing_cloud_account_id'],
+            marketplace=module.params['marketplace'],
+            billing_model=module.params['billing_model'],
+        ) 
+        try:
+            result['original_message'] = module.params
+            api_response = api_instance.create_kafka(_async, kafka_request_payload, async_req=True)
+            kafka_req_resp = api_response.get(2000)
+
+            if kafka_req_resp['status'] == 'accepted' or kafka_req_resp['status'] == 'ready' or kafka_req_resp['status'] == 'provisioning':
+                result['kafka_req_resp'] = kafka_req_resp.to_dict()
+                result['changed'] = True
+            
+            # exit the module and return the state 
+            module.exit_json(**result)
+        except rhoas_kafka_mgmt_sdk.ApiException as e:
+            print("Exception when calling DefaultApi -> create_kafka: %s\n" % e)
+            result['message'] = e
+            module.fail_json(msg='Failed to create kafka instance', **result)
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/library/create_kafka.py
+++ b/library/create_kafka.py
@@ -105,17 +105,6 @@ message:
     description: The output error / exception message that is returned in the case the module generates an error / exception.
     type: dict
     returned: in case of error / exception
-    sample: "original_message": {
-            "billing_cloud_account_id": "",
-            "billing_model": "marketplace",
-            "cloud_provider": "aws",
-            "instance_type": "developer",
-            "marketplace": "",
-            "name": "struttin",
-            "plan": "",
-            "reauthentication_enabled": "True",
-            "region": "eu-west-1"
-        }
 kafka_req_resp:
     description: The response object from the Kafka_mgmt API.
     "changed": true,

--- a/plugins/module/create_kafka.py
+++ b/plugins/module/create_kafka.py
@@ -2,6 +2,7 @@
 
 
 from __future__ import (absolute_import, division, print_function)
+from sys import api_version
 __metaclass__ = type
 
 DOCUMENTATION = r'''
@@ -21,6 +22,46 @@ options:
         description: Name of the Kafka instance
         required: true
         type: str
+    cloud_provider:
+        description: Cloud provider for the Kafka instance
+        required: false
+        type: str
+        default: aws
+    region:
+        description: Region of the Kafka instance
+        required: false
+        type: str
+        default: eu-west-1
+    reauthentication_enabled:
+        description: Reauthentication enabled for the Kafka instance
+        required: false
+        type: bool
+        default: true
+    plan:
+        description: Plan for the Kafka instance
+        required: false
+        type: str
+        default: ""
+    billing_cloud_account_id:
+        description: Billing cloud account id for the Kafka instance
+        required: false
+        type: str
+        default: ""
+    marketplace:
+        description: Marketplace for the Kafka instance
+        required: false
+        type: str
+        default: ""
+    billing_model:
+        description: Billing model for the Kafka instance
+        required: false
+        type: str
+        default: marketplace
+    instance_type:
+        description: Instance type for the Kafka instance
+        required: false
+        type: str
+        default: developer
  
 # Specify this value according to your collection
 # in format of namespace.collection.doc_fragment_name
@@ -33,9 +74,11 @@ author:
 
 EXAMPLES = r'''
 # Pass in a message
-- name: Test with a message
-  my_namespace.my_collection.create_kafka:
-    name: my-kafka
+  - name: Create kafka
+    create_kafka:
+      name: "struttin"
+    register:
+      kafka_req_resp 
 
  
 '''
@@ -43,41 +86,92 @@ EXAMPLES = r'''
 RETURN = r'''
 # These are examples of possible return values, and in general should use other names for return values.
 original_message:
-    description: The original name param that was passed in.
-    type: str
+    description: The original kafka request payload that was passed in.
+    type: dict
     returned: always
-    sample: 'hello world'
+    sample: "invocation": {
+        "module_args": {
+            "billing_cloud_account_id": "",
+            "billing_model": "marketplace",
+            "cloud_provider": "aws",
+            "instance_type": "developer",
+            "marketplace": "",
+            "name": "struttin",
+            "plan": "",
+            "reauthentication_enabled": "True",
+            "region": "eu-west-1"
+        }
 message:
-    description: The output message that the test module generates.
-    type: str
-    returned: always
-    sample: 'goodbye'
+    description: The output error / exception message that is returned in the case the module generates an error / exception.
+    type: dict
+    returned: in case of error / exception
+    sample: "original_message": {
+            "billing_cloud_account_id": "",
+            "billing_model": "marketplace",
+            "cloud_provider": "aws",
+            "instance_type": "developer",
+            "marketplace": "",
+            "name": "struttin",
+            "plan": "",
+            "reauthentication_enabled": "True",
+            "region": "eu-west-1"
+        }
+kafka_req_resp:
+    description: The response object from the Kafka_mgmt API.
+    "changed": true,
+        "failed": false,
+        "kafka_req_resp": {
+            "admin_api_server_url": "http://localhost:8000/data/kafka",
+            "billing_cloud_account_id": "",
+            "billing_model": "marketplace",
+            "bootstrap_server_host": "localhost:8000",
+            "browser_url": "http://localhost:8080/calbu9ccff6bdd4jsg30/dashboard",
+            "cloud_provider": "aws",
+            "created_at": "2020-10-05T12:51:24.053142+00:00",
+            "egress_throughput_per_sec": "1Mi",
+            "expires_at": "2022-06-18T05:27:01.816619+00:00",
+            "href": "/api/kafkas_mgmt/v1/kafkas/68Pr91QnNwW6Wis7J7jxM",
+            "id": "68Pr91QnNwW6Wis7J7jxM",
+            "ingress_throughput_per_sec": "1Mi",
+            "instance_type": "developer",
+            "instance_type_name": "Trial",
+            "kafka_storage_size": "10Gi",
+            "kind": "Kafka",
+            "marketplace": "",
+            "max_connection_attempts_per_sec": 50.0,
+            "max_data_retention_period": "P14D",
+            "max_partitions": 100.0,
+            "multi_az": false,
+            "name": "struttin",
+            "owner": "dsaridak",
+            "plan": "",
+            "reauthentication_enabled": true,
+            "region": "us-east-1",
+            "size_id": "x1",
+            "status": "ready",
+            "total_max_connections": 100.0,
+            "updated_at": "2020-10-05T12:56:36.362208+00:00",
+            "version": "3.0.1"
 '''
 
 from ansible.module_utils.basic import AnsibleModule
 import rhoas_kafka_mgmt_sdk
 from rhoas_kafka_mgmt_sdk.api import default_api
-from rhoas_kafka_mgmt_sdk.model.cloud_provider_list import CloudProviderList
-from rhoas_kafka_mgmt_sdk.model.cloud_region_list import CloudRegionList
-from rhoas_kafka_mgmt_sdk.model.error import Error
-from rhoas_kafka_mgmt_sdk.model.kafka_request import KafkaRequest
-from rhoas_kafka_mgmt_sdk.model.kafka_request_list import KafkaRequestList
 from rhoas_kafka_mgmt_sdk.model.kafka_request_payload import KafkaRequestPayload
-from rhoas_kafka_mgmt_sdk.model.kafka_update_request import KafkaUpdateRequest
-from rhoas_kafka_mgmt_sdk.model.metrics_instant_query_list import MetricsInstantQueryList
-from rhoas_kafka_mgmt_sdk.model.metrics_range_query_list import MetricsRangeQueryList
-from rhoas_kafka_mgmt_sdk.model.supported_kafka_instance_types_list import SupportedKafkaInstanceTypesList
-from rhoas_kafka_mgmt_sdk.model.version_metadata import VersionMetadata
-import util.auth 
-
-configuration = rhoas_kafka_mgmt_sdk.Configuration(
-    host = "https://api.openshift.com"
-)
+import auth.rhoas_auth as auth
 
 def run_module():
     # define available arguments/parameters a user can pass to the module
     module_args = dict(
         name=dict(type='str', required=True),
+        cloud_provider=dict(type='str', required=False, default='aws'),
+        region=dict(type='str', required=False, default="eu-west-1"),
+        reauthentication_enabled=dict(type='bool', required=False, default=True),
+        plan=dict(type='str', required=False, default=""),
+        billing_cloud_account_id=dict(type='str', required=False, default=""),
+        marketplace=dict(type='str', required=False, default=""),
+        billing_model=dict(type='str', required=False, default="marketplace"),
+        instance_type=dict(type='str', required=False, default="developer"),
     )
 
     # seed the result dict in the object
@@ -88,7 +182,8 @@ def run_module():
     result = dict(
         changed=False,
         original_message='',
-        message=''
+        message='',
+        kafka_req_resp=dict
     )
 
     # the AnsibleModule object will be our abstraction working with Ansible
@@ -103,46 +198,49 @@ def run_module():
     # if the user is working with this module in only check mode we do not
     # want to make any changes to the environment, just return the current
     # state with no modifications
+    # module.check_mode = False
     if module.check_mode:
         module.exit_json(**result)
 
- 
- 
-    token = util.auth.get_access_token()
+    token = auth.get_access_token()
+    
     configuration = rhoas_kafka_mgmt_sdk.Configuration(
-        access_token = token["access_token"]
+        # host = "https://api.openshift.com",
+        # for use with testing / mocking
+        host = "http://localhost:8000",
     )
+    
+    configuration.access_token = token["access_token"]
     # Enter a context with an instance of the API client
     with rhoas_kafka_mgmt_sdk.ApiClient(configuration) as api_client:
         # Create an instance of the API class
         api_instance = default_api.DefaultApi(api_client)
         _async = True # bool | Perform the action in an asynchronous manner
         kafka_request_payload = KafkaRequestPayload(
-            cloud_provider="cloud_provider_example",
-            name="name_example",
-            region="region_example",
+            cloud_provider=module.params['cloud_provider'],
+            name=module.params['name'],
+            region=module.params['region'],
             reauthentication_enabled=True,
-            plan="plan_example",
-            billing_cloud_account_id="billing_cloud_account_id_example",
-            marketplace="marketplace_example",
-            billing_model="billing_model_example",
-        ) # KafkaRequestPayload | Kafka data
+            plan=module.params['plan'],
+            billing_cloud_account_id=module.params['billing_cloud_account_id'],
+            marketplace=module.params['marketplace'],
+            billing_model=module.params['billing_model'],
+        ) 
         try:
-            api_response = api_instance.create_kafka(_async, kafka_request_payload)
-            # manipulate or modify the state as needed (this is going to be the
-            result['object'] = api_response
-            # use whatever logic you need to determine whether or not this module
-            # made any modifications to your target
-            result['changed'] = True
+            result['original_message'] = module.params
+            api_response = api_instance.create_kafka(_async, kafka_request_payload, async_req=True)
+            kafka_req_resp = api_response.get(2000)
 
-            # in the event of a successful module execution, you will want to
-            # simple AnsibleModule.exit_json(), passing the key/value results
+            if kafka_req_resp['status'] == 'accepted' or kafka_req_resp['status'] == 'ready' or kafka_req_resp['status'] == 'provisioning':
+                result['kafka_req_resp'] = kafka_req_resp.to_dict()
+                result['changed'] = True
+            
+            # exit the module and return the state 
             module.exit_json(**result)
         except rhoas_kafka_mgmt_sdk.ApiException as e:
-            print("Exception when calling DefaultApi->create_kafka: %s\n" % e)
-
-   
-
+            print("Exception when calling DefaultApi -> create_kafka: %s\n" % e)
+            result['message'] = e
+            module.fail_json(msg='Failed to create kafka instance', **result)
 
 def main():
     run_module()

--- a/plugins/module/create_kafka.py
+++ b/plugins/module/create_kafka.py
@@ -159,7 +159,7 @@ def run_module():
         plan=dict(type='str', required=False, default=""),
         billing_cloud_account_id=dict(type='str', required=False, default=""),
         marketplace=dict(type='str', required=False, default=""),
-        billing_model=dict(type='str', required=False, default="marketplace"),
+        billing_model=dict(type='str', required=False, default="standard"),
         instance_type=dict(type='str', required=False, default="developer"),
     )
 

--- a/plugins/module/create_kafka.py
+++ b/plugins/module/create_kafka.py
@@ -105,17 +105,6 @@ message:
     description: The output error / exception message that is returned in the case the module generates an error / exception.
     type: dict
     returned: in case of error / exception
-    sample: "original_message": {
-            "billing_cloud_account_id": "",
-            "billing_model": "marketplace",
-            "cloud_provider": "aws",
-            "instance_type": "developer",
-            "marketplace": "",
-            "name": "struttin",
-            "plan": "",
-            "reauthentication_enabled": "True",
-            "region": "eu-west-1"
-        }
 kafka_req_resp:
     description: The response object from the Kafka_mgmt API.
     "changed": true,

--- a/run.yml
+++ b/run.yml
@@ -1,0 +1,49 @@
+---
+- name: Create_kafka test
+  hosts: localhost
+  gather_facts: true
+  connection: local
+  tasks:
+  - name: Print the env var value
+    debug:
+      msg: "{{ lookup('env', 'OFFLINE_TOKEN') }}"
+  - name: Create kafka
+    create_kafka:
+      name: "struttin"
+      region: "us-east-1"
+    register:
+      kafka_req_resp 
+  - name: Debug create kafka
+    debug:
+      msg: "{{ kafka_req_resp }}"
+  - name: Create Service Account
+    create_service_account:
+      name: "struttin-jeeves"
+      description: "struttin-jeeves service account"
+    register:
+      srvce_acc_resp_obj
+  - name: Debug service account
+    debug:
+      msg: "{{ srvce_acc_resp_obj }}"
+  # - name: Create kafka ACL Service Binding
+  #   create_kafka_acl_binding:
+  #     # service_account_id: "{{ srvce_acc_resp_obj.client_id }}"
+  #     principal: "c20ace2f-961e-4c66-ab0a-17adeb3f0cc9"
+  #   register:
+  #     acl_resp_obj
+  # - name: Create Kafka Topic
+  #   create_kafka_topic:
+  #     name: "strut"
+  #     kafka_id: {{ kafka_req_resp.id }}
+  #     # kafka_id: "cci3uta87adqtsdn8v0g"
+  #     # partitions: 1
+  #     # replicas: 1
+  #     # config:
+  #     #   retention.ms: 604800000
+  #     #   segment.bytes: 1073741824
+  #   register:
+  #     create_topic_res_obj
+  # - name: Debug create Topic
+  #   debug:
+  #     msg: "{{ create_topic_res_obj }}"
+

--- a/scripts/local_dev.sh
+++ b/scripts/local_dev.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+ mkdir -p library
+ rm -rf library/*
+ cp -R plugins/module/*.py library


### PR DESCRIPTION
To verify:
checkout branch and run

`ansible-playbook 'run.yml' -vvv`

the -vvv flag here is for maximum verbosity i.e. debugging mode.

`OFFLINE_TOKEN` must be available as an envar for auth purposes. 

save this as `run.yaml` and a kafka should be created

```yaml
---
- name: Create_kafka test
  hosts: localhost
  gather_facts: true
  connection: local
  tasks:
  - name: Print the env var value
    debug:
      msg: "{{ lookup('env', 'OFFLINE_TOKEN') }}"
  - name: Create kafka
    create_kafka:
      name: "unique_name"
      billing_model: "standard"
      cloud_provider: "aws"
      region: "us-east-1"
      plan: "developer.x1"
      billing_cloud_account_id: ""
    register:
        kafka_req_resp
```